### PR TITLE
Option to only allow POST request methods

### DIFF
--- a/lib/omniauth/strategies/lti.rb
+++ b/lib/omniauth/strategies/lti.rb
@@ -8,10 +8,15 @@ module OmniAuth
       # - the value is the comsumer_secret
       option :oauth_credentials, {}
 
-      # Defaul username for users when LTI context doesn't provide a name
+      # Default username for users when LTI context doesn't provide a name
       option :default_user_name, 'User'
 
+      # Allow all request methods by default
+      option :only_accept_posts, false
+
       def callback_phase
+        # prevent invalid request types
+        return bad_request! unless request_method_allowed?
         # validate request
         return fail!(:invalid_credentials) unless valid_lti?
         #save the launch parameters for use in later request
@@ -56,6 +61,14 @@ module OmniAuth
       end
 
       private
+
+      def request_method_allowed?
+        !options.only_accept_posts || request.request_method == 'POST'
+      end
+
+      def bad_request!
+        [400, {}, ['400 Bad Request']]
+      end
 
       def valid_lti?
         key = request.params['oauth_consumer_key']


### PR DESCRIPTION
The Blackboard LMS LTI implementation appears to send a `HEAD` request to the LTI callback path. When that doesn't return a failure HTTP status, it follows up by trying a `GET` (which doesn't include any credentials/params etc so fails)

The proposed change would return a HTTP 400 Bad Request when the request is not a `POST` forcing it to 'do the right thing' and pass the full request with body etc as a post. 

To ensure backward compatibility (if there are some LTI tool consumers that require using a method other than `POST`), the default is to keep the status quo and allow all request methods. However, with the `only_accept_posts` option set true, a 400 will be returned.

On a side note, is there a reason the tool provider `valid_request!` method is used over `valid_request?` ?? It appears to defeat the purpose of returning `fail!(:invalid_credentials)` in the callback_phase method.  Thoughts?
