### PR TITLE
Use safe version of tool provider request validator

### DIFF
--- a/lib/omniauth/strategies/lti.rb
+++ b/lib/omniauth/strategies/lti.rb
@@ -74,8 +74,9 @@ module OmniAuth
         key = request.params['oauth_consumer_key']
         log :info, "Checking LTI params for key #{key}: #{request.params}"
         @tp = IMS::LTI::ToolProvider.new(key, options.oauth_credentials[key], request.params)
-        log :info, "Valid request? #{@tp.valid_request!(request)}"
-        @tp.valid_request!(request)
+        @tp.valid_request?(request).tap do |valid|
+          log :info, "Valid request? #{valid}"
+        end
       end
     end
   end


### PR DESCRIPTION
If the LTI request is invalid, let the `valid_lti?` helper method just return false. In turn, the request fail using the omniauth `fail!` helper

One option might be to also make this change in behaviour sit behind an option (default to keep behaviour as is?)

Let me know what you think. Happy to tweak either way.
